### PR TITLE
Make the creadential notice more clear

### DIFF
--- a/src/settings/components/Login.js
+++ b/src/settings/components/Login.js
@@ -70,7 +70,7 @@ export default class Login extends Component {
           </div>
         </form>
         <p className='security-disclaimer text-muted'>
-          <small>Your login credentials and 2FA code (when applicable) are <a href="https://docs.standardnotes.org/specification/encryption">processed locally</a> before sending directly to the Standard Notes server at sync.standardnotes.org. This add-on only stores an encryption/decryption key and the authentication token data sent back from the server to make future requests. This add-on also does not store any note data - only editor and tag data.</small>
+          <small>Only a password <a href="https://docs.standardnotes.org/specification/encryption">generated locally from your credentials</a> will be sent, directly to the Standard Notes server at sync.standardnotes.org. This add-on only stores encryption/decryption keys and the authentication token data sent back from the server to preserve the login status. This add-on also does not store any note data - only editor and tag data.</small>
         </p>
       </div>
     )

--- a/src/settings/components/Login.js
+++ b/src/settings/components/Login.js
@@ -70,7 +70,7 @@ export default class Login extends Component {
           </div>
         </form>
         <p className='security-disclaimer text-muted'>
-          <small>Your encrypted login credentials and 2FA code (when applicable) are sent directly to the Standard Notes server at sync.standardnotes.org and never stored locally on this machine. This add-on only stores an encryption key and the authentication token data sent back from the server to make future requests. This add-on also does not store any note data - only editor and tag data.</small>
+          <small>Your login credentials and 2FA code (when applicable) are <a href="https://docs.standardnotes.org/specification/encryption">processed locally</a> before sending directly to the Standard Notes server at sync.standardnotes.org. This add-on only stores an encryption/decryption key and the authentication token data sent back from the server to make future requests. This add-on also does not store any note data - only editor and tag data.</small>
         </p>
       </div>
     )


### PR DESCRIPTION
There were some points described in the notice were not quite precise and worried me:
- It said the password is uploaded (or maybe encrypted password) which is not precise and sounds like the server will know my password. But Standard Notes complies for End to End Encryption. The server should not be trusted. From the code I see it only sent one of three derrived key.
- It said the creadentials wouldn't be stored locally. Despite not directly as plaintext, the clipper stores the encryption/decription key and the auth key which are all creadentials and vital.

This PR fixes those.